### PR TITLE
Check that module has exports property

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -1126,6 +1126,6 @@ var bigInt = (function (undefined) {
 })();
 
 // Node.js check
-if (typeof module !== "undefined") {
+if (typeof module !== "undefined" && module.hasOwnProperty("exports")) {
     module.exports = bigInt;
 }


### PR DESCRIPTION
When testing an angular application, the global property module is created. Without this commit, module.exports is defined and other libraries think that they are in a node environment.
