### PR TITLE
Add .isProbablePrime()

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -741,13 +741,20 @@ var bigInt = (function (undefined) {
     };
     SmallInteger.prototype.isDivisibleBy = BigInteger.prototype.isDivisibleBy;
 
-    BigInteger.prototype.isPrime = function () {
-        var n = this.abs(),
-            nPrev = n.prev();
+    function isBasicPrime(v) {
+        var n = v.abs();
         if (n.isUnit()) return false;
         if (n.equals(2) || n.equals(3) || n.equals(5)) return true;
         if (n.isEven() || n.isDivisibleBy(3) || n.isDivisibleBy(5)) return false;
         if (n.lesser(25)) return true;
+        return null; // we don't know if it's prime: let the other functions figure it out
+    };
+
+    BigInteger.prototype.isPrime = function () {
+        if (isBasicPrime(this)) return true;
+        if (isBasicPrime(this) === false) return false;
+        var n = this.abs(),
+            nPrev = n.prev();
         var a = [2, 3, 5, 7, 11, 13, 17, 19],
             b = nPrev,
             d, t, i, x;

--- a/BigInteger.js
+++ b/BigInteger.js
@@ -772,6 +772,26 @@ var bigInt = (function (undefined) {
     };
     SmallInteger.prototype.isPrime = BigInteger.prototype.isPrime;
 
+    BigInteger.prototype.isProbablePrime = function (iterations) {
+        if (isBasicPrime(this)) return true;
+        if (isBasicPrime(this) === false) return false;
+        var n = this.abs();
+        var t;
+        if (arguments.length) {
+            t = iterations;
+        } else {
+            t = 5; // default (can be changed)
+        }
+        // use the Fermat primality test
+        for (var i = 0; i < t; i++) {
+            var a = bigInt.randBetween(2, n.minus(1));
+            if (a.isSmall) a = Math.floor(a); // randbetween doesn't provide an integer for small numbers
+            if (!bigInt(a).modPow(n.minus(1), n).equals(1)) return false; // definitely composite
+        }
+        return true; // large chance of being prime
+    };
+    SmallInteger.prototype.isProbablePrime = BigInteger.prototype.isProbablePrime;
+
     BigInteger.prototype.next = function () {
         var value = this.value;
         if (this.sign) {

--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ Returns `true` if the number is prime, `false` otherwise.
  - `bigInt(5).isPrime()` => `true`
  - `bigInt(6).isPrime()` => `false`
 
+`isProbablePrime([iterations])`
+---
+Returns `true` if the number is very likely to be positive, `false` otherwise.
+Argument is optional and determines the amount of iterations of the test (default: `5`). The more iterations, the lower chance of getting a false positive.
+This uses the [Fermat primality test](https://en.wikipedia.org/wiki/Fermat_primality_test).
+
+ - `bigInt(5).isProbablePrime()` => `true`
+ - `bigInt(49).isProbablePrime()` => `false`
+ - `bigInt(1729).isProbablePrime(50)` => `false`
+
 `isPositive()`
 ---
 Return `true` if the number is positive, `false` otherwise.


### PR DESCRIPTION
`.isProbablePrime` checks if the number provided to `bigInt` is prime, according to the [Fermat primality test](https://en.wikipedia.org/wiki/Fermat_primality_test). This is faster in many cases compared to the `.isPrime()` function (with my (limited) testing, it's around the same speed for composite numbers, and around 25% faster given primes). You can see my primitive test script here: https://gist.github.com/mariuszskon/ae3557ddab7e6b214402. Additionally, the amount of trials is configurable in the argument. 

I'm open to feedback. 