### PR TITLE
Use .npmignore to reduce size of npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+/.travis.yml
+/.npmignore
+/.gitignore
+/spec
+/benchmark
+/big-integer*.tgz
+/my.conf.js
+/node_modules


### PR DESCRIPTION
Currently the npm package for `BigInteger.js` takes up about 552KB, which is mostly the `benchmark` and `spec` directories:

```
$ du -ks * | sort -n
4	LICENSE
4	my.conf.js
4	package.json
16	README.md
20	BigInteger.min.js
40	BigInteger.js
164	benchmark
296	spec
```

These aren't needed for node.js apps or other libraries to just make use of `BigInteger` -- they're development and testing files that really shouldn't be included in the npm release package.

This PR adds a `.npmignore` file which excludes these directories from the npm package, reducing the size to about 84KB.