### PR TITLE
Use .npmignore with more feeling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,11 @@
 /big-integer*.tgz
 /my.conf.js
 /node_modules
+/*.csproj*
+/*.suo
+/bin
+/coverage
+/*.bat
+/obj
+/Properties
+/Web.*


### PR DESCRIPTION
Hi, me again!

In the release you pushed earlier today (after the .npmignore patch earlier) you seem to have also included a bunch of new extra files:

```
./BigInt.csproj
./BigInt.csproj.user
./BigInt.v11.suo
./bin
./bin/Bignum.dll
./bin/Bignum.pdb
./coverage
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/__root__
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/__root__/BigInteger.js.html
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/__root__/BigInteger.min.js.html
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/__root__/index.html
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/base.css
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/index.html
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/prettify.css
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/prettify.js
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/sort-arrow-sprite.png
./coverage/Chrome 35.0.1916 (Windows 7 0.0.0)/sorter.js
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/__root__
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/__root__/BigInteger.js.html
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/__root__/index.html
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/base.css
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/index.html
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/__root__
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/__root__/BigInteger.js.html
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/__root__/index.html
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/base.css
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/index.html
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/prettify.css
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/prettify.js
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/sort-arrow-sprite.png
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov-report/sorter.js
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/lcov.info
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/prettify.css
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/prettify.js
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/sort-arrow-sprite.png
./coverage/PhantomJS 1.9.8 (Windows 7 0.0.0)/sorter.js
./minify.bat
./obj
./obj/Debug
./obj/Debug/BigInt.csproj.FileListAbsolute.txt
./obj/Debug/BigInt.csprojResolveAssemblyReference.cache
./obj/Debug/Bignum.csproj.FileListAbsolute.txt
./obj/Debug/Bignum.csprojResolveAssemblyReference.cache
./obj/Debug/Bignum.dll
./obj/Debug/Bignum.pdb
./obj/Debug/DesignTimeResolveAssemblyReferencesInput.cache
./Properties
./Properties/AssemblyInfo.cs
./release.sh
./Web.config
./Web.Debug.config
./Web.Release.config
```

I've added filters in this PR that should catch all of these for you, since they make it even bigger than before. :)