### PR TITLE
gcd: use lowestOneBit, to iterative. lcm: multiply after divide.

### DIFF
--- a/spec/spec.js
+++ b/spec/spec.js
@@ -668,6 +668,7 @@ describe("BigInteger", function () {
             expect(bigInt.gcd(0, 56)).toEqual(56);
             expect(bigInt.gcd(42, 0)).toEqual(42);
             expect(bigInt.gcd(17, 103)).toEqual(1);
+            expect(bigInt.gcd(192, 84)).toEqual(12);
         });
     });
 


### PR DESCRIPTION
For performance improvement such as [peterolson/BigRational.js](https://github.com/peterolson/BigRational.js), it was reduced divide2 in gcd.
http://jsperf.com/bigint-gcd