### PR TITLE
Bugfix and improvement of modPow

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -598,8 +598,8 @@ var bigInt = (function (undefined) {
         if (mod.isZero()) throw new Error("Cannot take modPow with modulus 0");
         var r = CACHE[1],
             base = this.mod(mod);
-        if (base.isZero()) return CACHE[0];
         while (exp.isPositive()) {
+            if (base.isZero()) return CACHE[0];
             if (exp.isOdd()) r = r.multiply(base).mod(mod);
             exp = exp.divide(2);
             base = base.square().mod(mod);

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -609,6 +609,7 @@ describe("BigInteger", function () {
             //   https://projecteuler.net/problem=97
             expect(bigInt(28433).times(bigInt(2).modPow(7830457, "1e10")).plus(1).mod("1e10")).toEqual(8739992577);
             expect(bigInt(0).modPow(4, 20)).toEqual(0);
+            expect(bigInt(0).modPow(0, 20)).toEqual(1);
             try {
                 bigInt(4).modPow(9, 0);
                 expect(true).toBe(false);


### PR DESCRIPTION
Strictly speaking 0^0 == 1 (and not 0).
This also adds a shorcut in case the base becomes 0 at some point during the computation