### PR TITLE
Fix randBetween bias and range issues

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -1021,8 +1021,8 @@ var bigInt = (function (undefined) {
         a = parseValue(a);
         b = parseValue(b);
         var low = min(a, b), high = max(a, b);
-        var range = high.subtract(low);
-        if (range.isSmall) return low.add(Math.round(Math.random() * range));
+        var range = high.subtract(low).add(1);
+        if (range.isSmall) return low.add(Math.floor(Math.random() * range));
         var length = range.value.length - 1;
         var result = [], restricted = true;
         for (var i = length; i >= 0; i--) {


### PR DESCRIPTION
This corrects two problems:

1. When the min-max range was "small", the min and max integers had
   only half the probability of any of the numbers in between. This
   was due to how the random value was rounded, which effectively
   increased the integer output by 1 half of the time.

   This was fixed by flooring the value instead, and increasing the
   range by 1 to cover the max integer.

2. When the range was "big", the max value was treated as exclusive,
   which contradicts how it behaves in "small" mode and how
   randBetween is used internally. It is now treated as inclusive.