### PR TITLE
More reliable and faster isPrime()

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -794,11 +794,12 @@ var bigInt = (function (undefined) {
         if (isPrime !== undefined) return isPrime;
         var n = this.abs(),
             nPrev = n.prev();
-        var a = [2, 3, 5, 7, 11, 13, 17, 19],
+        var a = [2, 325, 9375, 28178, 450775, 9780504, 1795265022],
             b = nPrev,
             d, t, i, x;
         while (b.isEven()) b = b.divide(2);
         for (i = 0; i < a.length; i++) {
+            if (n.lesser(a[i])) continue;
             x = bigInt(a[i]).modPow(b, n);
             if (x.equals(Integer[1]) || x.equals(nPrev)) continue;
             for (t = true, d = b; t && d.lesser(nPrev); d = d.multiply(2)) {

--- a/BigInteger.js
+++ b/BigInteger.js
@@ -785,7 +785,7 @@ var bigInt = (function (undefined) {
         if (n.isUnit()) return false;
         if (n.equals(2) || n.equals(3) || n.equals(5)) return true;
         if (n.isEven() || n.isDivisibleBy(3) || n.isDivisibleBy(5)) return false;
-        if (n.lesser(25)) return true;
+        if (n.lesser(49)) return true;
         // we don't know if it's prime: let the other functions figure it out
     }
 

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -817,6 +817,12 @@ describe("BigInteger", function () {
                 expect(bigInt(primes[i]).isPrime()).toBe(true);
             }
         });
+        it("correctly identifies pseudo primes", function(){
+            var largePrimes = ["3825123056546413051", "3825123056546413051", "3825123056546413051", "318665857834031151167461"];
+            for (var i = 0; i < largePrimes.length; i++) {
+                expect(bigInt(largePrimes[i]).isPrime()).toBe(false);
+            }
+        });
         it("correctly rejects nonprime numbers", function () {
             var nonPrimes = [1, 4, 3 * 5, 4 * 7, 7 * 17, 3 * 103, 17 * 97, 7917];
             for (var i = 0; i < nonPrimes.length; i++) {


### PR DESCRIPTION
Ordinary isPrime() has a bug that it can not identify pseudo primes such as  3,825,123,056,546,413,051 = 149491 * 747451 * 34233211.
To make the function more reliable and faster, I use Jim Sinclair' SPRP bases sets. The sets can distinguish at least 2^64 number.
ref. https://miller-rabin.appspot.com/