### PR TITLE
Reliable isProbablePrime

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -788,13 +788,9 @@ var bigInt = (function (undefined) {
         if (n.lesser(49)) return true;
         // we don't know if it's prime: let the other functions figure it out
     }
-
-    BigInteger.prototype.isPrime = function () {
-        var isPrime = isBasicPrime(this);
-        if (isPrime !== undefined) return isPrime;
-        var n = this.abs(),
-            nPrev = n.prev();
-        var a = [2, 325, 9375, 28178, 450775, 9780504, 1795265022],
+    
+    function millerRabinTest(n, a) {
+        var nPrev = n.prev(),
             b = nPrev,
             d, t, i, x;
         while (b.isEven()) b = b.divide(2);
@@ -809,6 +805,12 @@ var bigInt = (function (undefined) {
             if (t) return false;
         }
         return true;
+    }
+
+    BigInteger.prototype.isPrime = function () {
+        var isPrime = isBasicPrime(this);
+        if (isPrime !== undefined) return isPrime;
+        return millerRabinTest(this.abs(), [2, 325, 9375, 28178, 450775, 9780504, 1795265022]);
     };
     SmallInteger.prototype.isPrime = BigInteger.prototype.isPrime;
 
@@ -817,12 +819,10 @@ var bigInt = (function (undefined) {
         if (isPrime !== undefined) return isPrime;
         var n = this.abs();
         var t = iterations === undefined ? 5 : iterations;
-        // use the Fermat primality test
-        for (var i = 0; i < t; i++) {
-            var a = bigInt.randBetween(2, n.minus(2));
-            if (!a.modPow(n.prev(), n).isUnit()) return false; // definitely composite
+        for (var a = [], i = 0; i < t; i++) {
+            a.push(bigInt.randBetween(2, n.minus(2)));
         }
-        return true; // large chance of being prime
+        return millerRabinTest(n, a);
     };
     SmallInteger.prototype.isProbablePrime = BigInteger.prototype.isProbablePrime;
 

--- a/README.md
+++ b/README.md
@@ -219,15 +219,15 @@ Returns `true` if the number is prime, `false` otherwise.
 
 Returns `true` if the number is very likely to be prime, `false` otherwise.
 Argument is optional and determines the amount of iterations of the test (default: `5`). The more iterations, the lower chance of getting a false positive.
-This uses the [Fermat primality test](https://en.wikipedia.org/wiki/Fermat_primality_test).
+This uses the [Miller Rabin test](https://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test).
 
  - `bigInt(5).isProbablePrime()` => `true`
  - `bigInt(49).isProbablePrime()` => `false`
- - `bigInt(1729).isProbablePrime(50)` => `false`
+ - `bigInt(1729).isProbablePrime()` => `false`
  
-Note that this function is not deterministic, since it relies on random sampling of factors, so the result for some numbers is not always the same. [Carmichael numbers](https://en.wikipedia.org/wiki/Carmichael_number) are particularly prone to give unreliable results.
-
-For example, `bigInt(1729).isProbablePrime()` returns `false` about 76% of the time and `true` about 24% of the time. The correct result is `false`.
+Note that this function is not deterministic, since it relies on random sampling of factors, so the result for some numbers is not always the same.
+If the number is composite then the Miller–Rabin primality test declares the number probably prime with a probability at most `4` to the power `−iterations`.
+If the number is prime, this function always returns `true`.
 
 #### `isUnit()`
 

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -837,7 +837,13 @@ describe("BigInteger", function () {
                 expect(bigInt(primes[i]).isProbablePrime()).toBe(true);
             }
         });
-        it("has false positive rate less than 0.5%", function () {
+        it("returns false for any Carmichael number", function () {
+            var carmichaelNumbers = [561, 1105, 1729, 2465, 2821, 6601, 8911, 10585, 15841, 29341, 41041, 46657, 52633, 62745, 63973, 75361, 101101, 115921, 126217, 162401, 172081, 188461, 252601, 278545, 294409, 314821, 334153, 340561, 399001, 410041, 449065, 488881, 512461];
+            for (var i = 0; i < carmichaelNumbers.length; i++) {
+                expect(bigInt(carmichaelNumbers[i]).isProbablePrime()).toBe(false);
+            }
+        });
+        it("has false positive rate less than 0.1%", function () {
             var totalPrimes = 0, falsePrimes = 0;
             for (var i = 1; i < 1e4; i++) {
                 var x = bigInt(i);
@@ -847,7 +853,7 @@ describe("BigInteger", function () {
                     falsePrimes++;
                 }
             }
-            expect(falsePrimes / totalPrimes < 0.005).toBe(true);
+            expect(falsePrimes / totalPrimes < 0.001).toBe(true);
         });
     });
 


### PR DESCRIPTION
Make isProbablePrime more reliable.

Miller-Rabin Test with random sampling can detect some pseudo primes as a composite number.
And with my local testing, the new isProbablePrime() works as fast as the original one.
ref. https://github.com/peterolson/BigInteger.js/pull/48#issue-45877579