### PR TITLE
Changed modPow to also handle negative exponents

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -683,6 +683,10 @@ var bigInt = (function (undefined) {
         if (mod.isZero()) throw new Error("Cannot take modPow with modulus 0");
         var r = Integer[1],
             base = this.mod(mod);
+        if (exp.isNegative()) {
+            exp = exp.multiply(Integer[-1]);
+            base = base.modInv(mod);
+        }
         while (exp.isPositive()) {
             if (base.isZero()) return Integer[0];
             if (exp.isOdd()) r = r.multiply(base).mod(mod);

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -630,6 +630,9 @@ describe("BigInteger", function () {
             } catch (e) {
                 expect(true).toBe(true);
             }
+
+            expect(bigInt(2).modPow(-3, 11)).toEqualBigInt(7);
+            expect(bigInt(76455).modPow(-3758223534, 346346)).toEqualBigInt(339949);
         });
     });
 


### PR DESCRIPTION
Allow `modPow` to also handle negative exponents as a modular inverse followed by a normal modular exponentiation.

Right now `modPow` returns `0` which is unexpected behaviour since then `(a^b mod n)*(a^(-b) mod n) mod n != 1`. With the proposed changes `modInv` can throw an error if `a` has no multiplicative inverse but it is a more descriptive error than simply letting `modPow` return `0`. Applying the changes results in the same behaviour as implementations of other languages such as Java's `BigIntegers`'s `modPow`, PHP's `bmodpow` and python's `pow`.

For a reference on how to calculate negative exponents, see for example:
https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Modular_exponentiation.html

See also #184 