### PR TITLE
Update type definition and README.md with isPrime's optional strict parameter

### DIFF
--- a/BigInteger.d.ts
+++ b/BigInteger.d.ts
@@ -200,7 +200,7 @@ declare namespace bigInt {
         /**
          * Returns true if the number is prime, false otherwise.
          */
-        isPrime(): boolean;
+        isPrime(strict?: boolean): boolean;
 
         /**
          * Returns true if the number is very likely to be prime, false otherwise.

--- a/README.md
+++ b/README.md
@@ -214,9 +214,10 @@ Returns `false` for `0` and `-0`.
  - `bigInt(54).isPositive()` => `true`
  - `bigInt(-1).isPositive()` => `false`
 
-#### `isPrime()`
+#### `isPrime(strict?)`
 
 Returns `true` if the number is prime, `false` otherwise.
+Set "strict" boolean to true to force GRH-supported lower bound of 2*log(N)^2.
 
  - `bigInt(5).isPrime()` => `true`
  - `bigInt(6).isPrime()` => `false`


### PR DESCRIPTION
I'm building an interactive RSA tool, and I just about finished the key generation for up to 4086-bit keys when I realized Safari has yet to implement BigInt. So, needless to say, I wished to thank you for this library/polyfill and contribute what little I can to it.

Also, is there an ELI5 for that strict parameter? I understand it changes how many integers it tests against, but I haven't a clue what GRH is, lol.