### PR TITLE
fix Asynch Module Definition

### DIFF
--- a/BigInteger.js
+++ b/BigInteger.js
@@ -1447,7 +1447,7 @@ if (typeof module !== "undefined" && module.hasOwnProperty("exports")) {
 
 //amd check
 if (typeof define === "function" && define.amd) {
-    define("big-integer", [], function () {
+    define( function () {
         return bigInt;
     });
 }


### PR DESCRIPTION
When using require.js define now correctly returns bigInt instead of undefined.

 The minimized version still needs to be updated.