### PR TITLE
Do not use an authenticated URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "./BigInteger",
   "repository": {
     "type": "git",
-    "url": "git@github.com:peterolson/BigInteger.js.git"
+    "url": "github:peterolson/BigInteger.js"
   },
   "keywords": [
     "math",


### PR DESCRIPTION
Allow to use the package metadata for anonymous clones, which solves issues like the one described at [1]. For convenience, use the short-hand notation described at [2].

[1]: https://github.com/oss-review-toolkit/ort/issues/8212
[2]: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository